### PR TITLE
Preventing fields being named after 1 of the faulty keywords

### DIFF
--- a/packages/gatsby-source-graphcms/src/__tests__/faulty-keywords.test.js
+++ b/packages/gatsby-source-graphcms/src/__tests__/faulty-keywords.test.js
@@ -1,0 +1,46 @@
+const { GraphQLClient } = require('graphql-request')
+const { faultyKeywords, checkForFaultyFields } = require('../faulty-keywords')
+
+const endpoint = 'https://api.graphcms.com/simple/v1/vinylbase'
+const client = new GraphQLClient(endpoint)
+
+const faultyQuery = `{
+  allArtists {
+    records {
+      tracks {
+        record {
+          tracks {
+            id
+            length
+          }
+        }
+      }
+    }
+  }
+}`
+
+const swellQuery = `{
+  allArtists {
+    records {
+      tracks {
+        record {
+          tracks {
+            id
+          }
+        }
+      }
+    }
+  }
+}`
+
+it('returns true if the query contains a faulty keyword', async () => {
+  expect.assertions(1)
+  const queryResult = await client.request(faultyQuery)
+  expect(checkForFaultyFields(queryResult, faultyKeywords)).toBe(true)
+})
+
+it('returns false if the query does not contain any faulty keywords', async () => {
+  expect.assertions(1)
+  const queryResult = await client.request(swellQuery)
+  expect(checkForFaultyFields(queryResult, faultyKeywords)).toBe(false)
+})

--- a/packages/gatsby-source-graphcms/src/faulty-keywords.js
+++ b/packages/gatsby-source-graphcms/src/faulty-keywords.js
@@ -1,0 +1,30 @@
+import R from "ramda"
+
+export const faultyKeywords = [
+  'length',
+  'prototype',
+  'constructor'
+]
+
+export const keywordsError = `One or more of your project's fields has a name matching one of ( ${faultyKeywords} ) which due to current limitations has to change in order for the plugin to get all the data correctly`
+
+// Checking if the query we pass in config has any of the faulty fields
+export const checkForFaultyFields = (data, keywords) => {
+  const getAllKeys = (obj) => {
+    const all = []
+    const getKeys = (obj) =>
+      all.push(
+        ...Object.keys(obj).map(key => 
+          obj[key] instanceof Object
+          ? getKeys(obj[key])
+          : key
+        )
+      )
+    getKeys(obj)
+    return all
+  }
+
+  const containsKeywords = R.intersection(getAllKeys(data), keywords).length > 0
+
+  return containsKeywords
+}

--- a/packages/gatsby-source-graphcms/src/faulty-keywords.js
+++ b/packages/gatsby-source-graphcms/src/faulty-keywords.js
@@ -1,9 +1,9 @@
 import R from "ramda"
 
 export const faultyKeywords = [
-  'length',
-  'prototype',
-  'constructor'
+  `length`,
+  `prototype`,
+  `constructor`,
 ]
 
 export const keywordsError = `One or more of your project's fields has a name matching one of ( ${faultyKeywords} ) which due to current limitations has to change in order for the plugin to get all the data correctly`

--- a/packages/gatsby-source-graphcms/src/gatsby-node.js
+++ b/packages/gatsby-source-graphcms/src/gatsby-node.js
@@ -30,7 +30,7 @@ exports.sourceNodes = async (
     const userQueryResult = await client.request(query)
     // keywords workaround
     if (checkForFaultyFields(userQueryResult, faultyKeywords)) {
-      throw new Error(keywordsError)
+      reporter.panic(`gatsby-source-graphcms: ${keywordsError}`)
     }
     if (DEBUG_MODE) {
       const jsonUserQueryResult = JSON.stringify(userQueryResult, undefined, 2)

--- a/packages/gatsby-source-graphcms/src/gatsby-node.js
+++ b/packages/gatsby-source-graphcms/src/gatsby-node.js
@@ -2,6 +2,11 @@ import { GraphQLClient } from "graphql-request"
 import R from "ramda"
 import crypto from "crypto"
 import { extractTypeName } from "./util"
+import {
+  faultyKeywords,
+  keywordsError,
+  checkForFaultyFields
+} from './faulty-keywords'
 
 const SOURCE_NAME = `GraphCMS`
 
@@ -23,6 +28,10 @@ exports.sourceNodes = async (
 
   if (query) {
     const userQueryResult = await client.request(query)
+    // keywords workaround
+    if (checkForFaultyFields(userQueryResult, faultyKeywords)) {
+      throw new Error(keywordsError)
+    }
     if (DEBUG_MODE) {
       const jsonUserQueryResult = JSON.stringify(userQueryResult, undefined, 2)
       console.log(`\ngatsby-source-graphcms: GraphQL query results: ${jsonUserQueryResult}`)

--- a/packages/gatsby-source-graphcms/src/gatsby-node.js
+++ b/packages/gatsby-source-graphcms/src/gatsby-node.js
@@ -5,7 +5,7 @@ import { extractTypeName } from "./util"
 import {
   faultyKeywords,
   keywordsError,
-  checkForFaultyFields
+  checkForFaultyFields,
 } from './faulty-keywords'
 
 const SOURCE_NAME = `GraphCMS`


### PR DESCRIPTION
- Added `faulty-keywords.js` containing:
  - Array of keywords that will potentially break our data generation
  - Error message to throw
  - Function checking the object for any of the keywords
- `If` statement throwing an error in `gatsby-node.js` whenever it detects any of the field is named after a keyword